### PR TITLE
validator progress bar bugfix

### DIFF
--- a/src/gui/validatorview.py
+++ b/src/gui/validatorview.py
@@ -158,7 +158,8 @@ class ValidatorView(QWidget):
 		self.ui.centralWidget.setPalette(palette)
 		
 		# reset progress bar and hide it.
-		self.ui.algorithmProgressBar.setValue(0)
+		if self.ui.algorithmProgressBar.value() == 100:
+			self.ui.algorithmProgressBar.setValue(0)
 		self.ui.algorithmProgressBar.hide()
 		
 		# reset individual counts
@@ -246,6 +247,8 @@ class ValidatorView(QWidget):
 			self.ui.algorithmProgressBar.setStyleSheet(ValidatorView.WARNING_PROGRESSBAR)
 		else:
 			self.ui.algorithmProgressBar.setStyleSheet(ValidatorView.ERROR_PROGRESSBAR)
+		
+		self.ui.algorithmProgressBar.show()
 
 	def addWidgetToMessage(self, msg: ValidatorMessage) -> None:
 		"""


### PR DESCRIPTION
We want the validator's progress bar to remain shown while the validator is running even when the validator is cleared. When the validator is not running, we want the clear button to hide the validator.