### PR TITLE
increase notification show time

### DIFF
--- a/src/gui/facileview.py
+++ b/src/gui/facileview.py
@@ -391,7 +391,7 @@ class FacileView(QMainWindow):
 		fadeOutTimer = QTimer()
 		
 		waitTimer.setSingleShot(True)
-		waitTimer.setInterval(1000)
+		waitTimer.setInterval(3000)
 		
 		effect = QGraphicsOpacityEffect(label)
 		label.setGraphicsEffect(effect)


### PR DESCRIPTION
notifications are now shown at full opacity for 3 seconds instead of 1 second.

closes #48 