### PR TITLE
Fixed graphics issues with component graphics separation

### DIFF
--- a/src/data/tguim/targetguimodel.py
+++ b/src/data/tguim/targetguimodel.py
@@ -125,8 +125,6 @@ class TargetGuiModel(QObject):
 		:return: The component that was created
 		:rtype: 'Component'
 		"""
-		# from pprint import pprint
-		# pprint(newSuperToken.asDict())
 
 		if parentToken is None:
 			parentComponent = self._root

--- a/src/graphics/tguim/tguimscene.py
+++ b/src/graphics/tguim/tguimscene.py
@@ -66,9 +66,6 @@ class TGUIMScene(QGraphicsScene):
 			self.addItem(graphics)
 
 		def onNewComponent(newComponent):
-			from pprint import pprint
-			pprint(newComponent.getSuperToken())
-
 			parentGraphics = self.getGraphics(newComponent.getParent())
 			graphics = self.createComponentGraphics(newComponent, parentGraphics)
 			if parentGraphics is None:


### PR DESCRIPTION
I think I fixed both issues with the graphics that Philippe was having. They are:

1. 2nd level components were shown as top-level.
2. opening a 2nd window in the target application caused things to crash because components weren't linked together in the graphics hierarchy correctly.

Both issues were caused by the root not being mapped to its "invisible" graphics in the TGUIM scene.