### PR TITLE
"Install API" checkbox in compiler dialog now works.

### DIFF
--- a/src/data/compilationprofile.py
+++ b/src/data/compilationprofile.py
@@ -36,7 +36,7 @@ class CompilationProfile:
 		Pdf = 1
 	
 	def __init__(self, docTypes: Set['CompilationProfile.DocType'], compResOpts: Set['MatchOption'],
-	             apiFolderDir, interpExeDir):
+	             apiFolderDir, interpExeDir, installApi: bool):
 		"""
 		Construct the CompilationProfile containing the information from ApiCompilerDialog.
 		"""
@@ -45,3 +45,4 @@ class CompilationProfile:
 		self.docTypes = docTypes
 		self.apiFolderDir = apiFolderDir
 		self.interpExeDir = interpExeDir
+		self.installApi = installApi

--- a/src/data/compiler/compiler.py
+++ b/src/data/compiler/compiler.py
@@ -171,3 +171,9 @@ class Compiler():
         initFile.close()
         
         self.generateCustomApp()
+
+        # Auto install API if user selected to do so.
+        if self._compProf.installApi:
+            os.chdir(self._saveFolder)
+            os.system(self._compProf.interpExeDir + " -m pip install .")
+

--- a/src/data/compiler/setup-template.txt
+++ b/src/data/compiler/setup-template.txt
@@ -3,10 +3,9 @@ from setuptools import setup, find_packages
 setup(
   name='{projectName}',
   version='{projectVersion}',
-  packages=find_packages(),
+  packages=['{projectName}'],
   #TODO: package_data values will need to change when we figure out how to include Facile's tguim and tguiil as binaries.
-  package_data={{'{projectName}': ['data/*.py', 'data/tguim/*.py',
-  'tguiil/*.py', 'Documentation/*', '*']}},
+  package_data={{'{projectName}': ['data/*.py', 'data/tguim/*.py', 'tguiil/*.py', 'Documentation/*', '*']}},
 
   #Insert additional Metadata for PyPI here.
 

--- a/src/gui/apicompilerdialog.py
+++ b/src/gui/apicompilerdialog.py
@@ -190,10 +190,9 @@ class ApiCompilerDialog(QDialog):
 		
 		apiFolderDir = self.ui.apiLocation.text()
 		interpExeDir = self.ui.interpreterLocation.text()
+		installApi = self.ui.checkBoxInstallAPI.isChecked()
 		
-		theCompilationProfile = CompilationProfile(setDocType, setcompResOpts, apiFolderDir, interpExeDir)
-		
-		
+		theCompilationProfile = CompilationProfile(setDocType, setcompResOpts, apiFolderDir, interpExeDir, installApi)
 		
 		# if there are any errors, show them, then return.
 		if len(errors) != 0:


### PR DESCRIPTION
If "Install API" is selected, the API's Python package will be automatically installed to your interpreter.