### PR TITLE
Enforce valid project name when creating a new project

### DIFF
--- a/src/data/compiler/compiler.py
+++ b/src/data/compiler/compiler.py
@@ -39,6 +39,7 @@ class Compiler():
         self.statem = sm.StateMachine.instance
         self._compProf = compProf
         self._name = self.statem._project.getName()
+        self._apiName = self.statem._project.getAPIName()
         self._backend = self.statem._project.getBackend()
         self._exeLoc = self.statem._project.getExecutableFile()
         self._opts = compProf.compResOpts
@@ -47,7 +48,7 @@ class Compiler():
         
         # Save Folders
         self._saveFolder = compProf.apiFolderDir + '/'
-        self._srcFolder = os.path.join(self._saveFolder, self.statem._project.getName() + '/')
+        self._srcFolder = os.path.join(self._saveFolder, self._apiName + '/')
         self._docFolder = os.path.join(self._srcFolder, 'Documentation/')
         
         # Make all save folders if they don't exist
@@ -153,7 +154,7 @@ class Compiler():
 
         # Create setup.py so user can install install API as a package with pip.
         setupTempFile = open(os.path.join(dir, "setup-template.txt"), 'r')
-        setupStr = setupTempFile.read().format(projectName=self.statem._project.getName(),
+        setupStr = setupTempFile.read().format(projectName=self.statem._project.getAPIName(),
                                                projectVersion='0.1.0')  # TODO Add versioning
         setupTempFile.close()
         setupFile = open(os.path.join(self._saveFolder, 'setup.py'), 'w')

--- a/src/data/project.py
+++ b/src/data/project.py
@@ -244,6 +244,16 @@ class Project:
 		"""
 		
 		return self._name
+
+	def getAPIName(self) -> str:
+		"""
+		Gets the name of the API.
+
+		:return: The API's name.
+		:rtype: str
+		"""
+
+		return self._name.replace(" ", "_")
 	
 	def getExecutableFile(self) -> str:
 		"""

--- a/src/gui/apicompilerdialog.py
+++ b/src/gui/apicompilerdialog.py
@@ -207,7 +207,7 @@ class ApiCompilerDialog(QDialog):
 		c = Compiler(theCompilationProfile).compileAPI()
 		
 		# no error? run document generation
-		projectName = sm.StateMachine.instance._project.getName()
+		projectName = sm.StateMachine.instance._project.getAPIName()
 		docGenerator = DocGenerator(setDocType, projectName)
 		docGenerator.createDoc()
 		

--- a/src/gui/newprojectdialog.py
+++ b/src/gui/newprojectdialog.py
@@ -187,8 +187,8 @@ class NewProjectDialog(QDialog):
 		errors = []
 		if not name:
 			errors.append("Need project name")
-		elif not name.isidentifier():
-			errors.append("The project name must be a valid python identifier")
+		if not name.replace(" ", "_").isidentifier():
+			errors.append("The project name may only contain alphanumeric characters and spaces and cannot begin with a number.")
 		if not description:
 			errors.append("Need project description")
 		


### PR DESCRIPTION
Since the project name is also the name of the package that's generated, it needs to be a valid python identifier. If it has spaces or breaks the rules in some other way, the user will never be able to use the generated API without putting their script directly alongside the generated application.py.

closes #191 