### PR TITLE
Disable compiler until validation succeeds

### DIFF
--- a/src/data/statemachine.py
+++ b/src/data/statemachine.py
@@ -508,7 +508,6 @@ class StateMachine:
 		ui.actionAutoExplore.setChecked(False)
 		ui.actionAdd_Action_Pipeline.setEnabled(True)
 		ui.actionPower_App.setEnabled(True)
-		ui.actionShow_API_Compiler.setEnabled(True)
 		ui.actionValidate.setEnabled(True)
 		
 		# enable validator buttons
@@ -537,7 +536,6 @@ class StateMachine:
 		self.view.ui.actionShow_Token_Tags.setEnabled(True)
 		self.view.ui.actionAdd_Behavior.setEnabled(True)
 		self.view.ui.actionPower_App.setEnabled(True)
-		self.view.ui.actionShow_API_Compiler.setEnabled(True)
 		self.view.ui.actionValidate.setEnabled(True)
 	
 	def _state_EXPLORATION(self, event: Event, previousState: State, *args, **kwargs) -> None:
@@ -573,7 +571,6 @@ class StateMachine:
 		self.view.ui.actionShow_Token_Tags.setEnabled(True)
 		self.view.ui.actionAdd_Behavior.setEnabled(False)
 		self.view.ui.actionPower_App.setEnabled(True)
-		self.view.ui.actionShow_API_Compiler.setEnabled(True)
 		self.view.ui.actionValidate.setEnabled(True)
 	
 	############################################################################

--- a/src/data/validator.py
+++ b/src/data/validator.py
@@ -24,6 +24,7 @@ class Validator(QThread):
 	
 	sentMessage = Signal(ValidatorMessage)
 	updateProgress = Signal(float)
+
 	
 	def __init__(self):
 		"""

--- a/src/gui/ui/facileview.ui
+++ b/src/gui/ui/facileview.ui
@@ -156,6 +156,9 @@
    </widget>
   </widget>
   <widget class="QToolBar" name="toolBar">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
    <property name="sizePolicy">
     <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
      <horstretch>0</horstretch>
@@ -377,6 +380,9 @@
    <property name="checkable">
     <bool>true</bool>
    </property>
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset resource="../../../icons.qrc">
      <normaloff>:/icon/resources/icons/office/compile-python.png</normaloff>:/icon/resources/icons/office/compile-python.png</iconset>
@@ -385,7 +391,7 @@
     <string>Show API Compiler</string>
    </property>
    <property name="toolTip">
-    <string>Compile</string>
+    <string>Compile the API</string>
    </property>
   </action>
   <action name="actionValidate">

--- a/src/gui/validatorview.py
+++ b/src/gui/validatorview.py
@@ -150,6 +150,7 @@ class ValidatorView(QWidget):
 		self.ui.runButton.setEnabled(False)
 		self.ui.stopButton.setEnabled(True)
 		sm.StateMachine.instance.view.ui.actionValidate.setEnabled(False)
+		sm.StateMachine.instance.view.ui.actionShow_API_Compiler.setEnabled(False) # disable api compiler action
 	
 	@Slot()
 	def clear(self) -> None:
@@ -316,5 +317,7 @@ class ValidatorView(QWidget):
 			self.ui.runButton.setEnabled(True)
 			self.ui.stopButton.setEnabled(False)
 			sm.StateMachine.instance.view.ui.actionValidate.setEnabled(True)
-		
 
+			# if there are no errors and we've finished, enable the API compiler.
+			if self._mostSevere != ValidatorMessage.Level.Error.value:
+				sm.StateMachine.instance.view.ui.actionShow_API_Compiler.setEnabled(True)


### PR DESCRIPTION
The compiler is disabled by default. When the validator is run, it also disables the compiler. The compiler is only re-enabled when validation succeeds.

This isn't fool-proof. The user could validate, make bad changes, and then compile. The only ways I see to solve this are:

1. Disable compiler whenever anything is edited - a lot of little changes.
2. When the user opens the compiler, we could run the validator automatically. This would take quite a bit of rework though and will have to be done later.