### PR TITLE
compile forces verification first

### DIFF
--- a/src/data/statemachine.py
+++ b/src/data/statemachine.py
@@ -27,7 +27,7 @@ from enum import Enum, auto
 
 from PySide2.QtCore import Slot, QTimer
 from PySide2.QtGui import QStandardItem, QStandardItemModel, Qt, QIcon, QPixmap
-from PySide2.QtWidgets import QGraphicsScene, QDialog, QLabel, QVBoxLayout, QWidget, QSizePolicy
+from PySide2.QtWidgets import QGraphicsScene, QDialog, QMessageBox, QWidget, QSizePolicy
 
 import data.tguim.visibilitybehavior as vb
 from gui.facilegraphicsview import FacileGraphicsView
@@ -403,8 +403,24 @@ class StateMachine:
 		v._actionPipelinesMenu.actionSelected.connect(self.setCurrentActionPipeline)
 		
 		def onAPICompiler():
-			apicomp = ApiCompilerDialog()
-			apicomp.exec_()
+			ui.validatorDockWidget.show()
+
+			def onVerificationComplete(success):
+				if success:
+					apicomp = ApiCompilerDialog()
+					apicomp.exec_()
+				else:
+					msg = QMessageBox()
+					msg.setIcon(QMessageBox.Critical)
+					msg.setText("Error")
+					msg.setInformativeText("Please resolve all verification errors before compiling.")
+					msg.setWindowTitle("Error")
+					msg.exec_()
+				v.ui.validatorView.finished.disconnect(onVerificationComplete)
+
+			v.ui.validatorView.finished.connect(onVerificationComplete)
+			v.ui.validatorView.onRun()
+
 	
 		ui.actionShow_API_Compiler.triggered.connect(onAPICompiler)
 

--- a/src/gui/validatorview.py
+++ b/src/gui/validatorview.py
@@ -51,6 +51,7 @@ class ValidatorView(QWidget):
 	ran = Signal()
 	refreshed = Signal()
 	cleared = Signal()
+	finished = Signal(bool)
 	
 	LABEL_STYLE = '<span style="font-weight:bold;color:{color};">{{}}</span> {label}'
 	
@@ -316,5 +317,9 @@ class ValidatorView(QWidget):
 			self.ui.runButton.setEnabled(True)
 			self.ui.stopButton.setEnabled(False)
 			sm.StateMachine.instance.view.ui.actionValidate.setEnabled(True)
-		
+
+			if self._mostSevere == ValidatorMessage.Level.Error.value:
+				self.finished.emit(False)
+			else:
+				self.finished.emit(True)
 


### PR DESCRIPTION
This PR implements the solution that @Frenchman98 suggested in #206.

The validate button will run the validator with no actions following.

The compile button will run the validator and if errors exist, a message is shown telling the user to correct the errors before compiling. If there are no errors, the compile dialog is shown.