### PR TITLE
Fix action icon noise

### DIFF
--- a/src/gui/actionmenuitem.py
+++ b/src/gui/actionmenuitem.py
@@ -21,9 +21,10 @@
 This module contains the ActionMenuItem() Class.
 """
 
-from PySide2.QtWidgets import QWidget, QGraphicsScene, QDialog
+from PySide2.QtWidgets import QWidget, QGraphicsScene, QGraphicsRectItem, QApplication
 from PySide2.QtCore import Qt, QEvent
 from PySide2.QtGui import QContextMenuEvent, QPainter, QPixmap
+
 from gui.ui.ui_actionmenuitem import Ui_Form as Ui_ActionMenuItem
 from graphics.apim.actionicongraphics import ActionIconGraphics
 from data.apim.actionpipeline import ActionPipeline
@@ -56,10 +57,14 @@ class ActionMenuItem(QWidget):
 		self._action = action
 		
 		#Add ActionGraphics to Graphics View
+		side = 10_000_000
+		background = QGraphicsRectItem(-side / 2, -side / 2, side, side, None)
+		background.setBrush(QApplication.instance().palette(self).window())
 		self._actionGraphics = ActionIconGraphics(self._action)
 		self._scene = QGraphicsScene()
-		self._scene.addItem(self._actionGraphics)
-		
+		self._scene.addItem(background)
+		self._actionGraphics.setParentItem(background)
+
 		# set action name text field and shrink action graphics to fit.
 		self.update()
 		
@@ -167,5 +172,5 @@ class ActionMenuItem(QWidget):
 		self._pix = QPixmap(br.width(), br.height())
 		self._pix.setMask(self._pix.createHeuristicMask())
 		painter = QPainter(self._pix)
-		self._scene.render(painter)
+		self._scene.render(painter, source=br)
 		self.ui.actionIcon.setPixmap(self._pix)


### PR DESCRIPTION
It appears that if you render a scene, random noise can populate the area not occupied by QGraphicsItems. 

It was an easy fix - just put a large item behind the action icon. I had to match the color of the background by getting the window color of the action menu item.

resolves #209 

![image](https://user-images.githubusercontent.com/19242154/79941920-62cf7280-841a-11ea-976b-7ef841f53535.png)