### PR TITLE
disable "add to current action pipeline" when none exists.

### DIFF
--- a/src/gui/actionmenuitem.py
+++ b/src/gui/actionmenuitem.py
@@ -115,7 +115,7 @@ class ActionMenuItem(QWidget):
 		:return: None
 		:rtype: NoneType
 		"""
-		
+		self.menu.prerequest()
 		self.menu.exec_(event.globalPos())
 	
 	def mouseDoubleClickEvent(self, event: QEvent):

--- a/src/qt_models/actionitemmenu.py
+++ b/src/qt_models/actionitemmenu.py
@@ -72,4 +72,9 @@ class ActionItemMenu(QMenu):
 		
 		:return: None
 		"""
-		pass
+		cap = sm.StateMachine.instance.getCurrentActionPipeline()
+
+		if cap:
+			self._addAction.setEnabled(True)
+		else:
+			self._addAction.setEnabled(False)

--- a/src/qt_models/componentactionitemmenu.py
+++ b/src/qt_models/componentactionitemmenu.py
@@ -54,4 +54,5 @@ class ComponentActionItemMenu(ActionItemMenu):
 		
 		:return: None
 		"""
+		ActionItemMenu.prerequest(self)
 		pass


### PR DESCRIPTION
On right-click, the "add to current action pipeline" item will be disabled if there is no current action pipeline.

resolves #212 