### PR TITLE
dropdown menu for port types

### DIFF
--- a/src/data/apim/port.py
+++ b/src/data/apim/port.py
@@ -32,6 +32,10 @@ class PortException(Exception):
     def __init__(self, msg: str):
         Exception.__init__(self, msg)
 
+class InvalidDataTypeException(PortException):
+    def __init__(self, msg: str):
+        Exception.__init__(self, msg)
+
 
 class Port(Entity):
     """
@@ -166,22 +170,27 @@ class Port(Entity):
         """
         return self._dataType
 
-    def setDataType(self, newType: type) -> None:
+    def setDataType(self, newType: type, enforceType=True) -> None:
         """
         Sets the data type of the port. (A Python type [e.g. int, str, bool, etc.])
 
-        :raises: TypeError if newType is not a valid type
+        :raises: InvalidDataTypeError if newType is not a valid type
 
         :param newType: A Python type [e.g. int, str, bool, etc.].
         :type newType: type
+        :param enforceType: If true, a check will be performed to make sure that the type is valid.
+        :type enforceType: bool
         :return: None
         :rtype: NoneType
         """
         if type(newType) == type:
             self._dataType = newType
             self.getProperties().getProperty("Data Type")[1].setValue(newType.__name__)
+        elif not enforceType:
+            self._dataType = newType
+            self.getProperties().getProperty("Data Type")[1].setValue(newType)
         else:
-            raise TypeError("setDataType()'s input parameter must specify a Python type [e.g. int, str, bool].")
+            raise InvalidDataTypeException("setDataType()'s input parameter must specify a Python type [e.g. int, str, bool].")
         
         if self._action is not None:
             self._action.synchronizeWrappers()

--- a/src/gui/ui/porteditorwidget.ui
+++ b/src/gui/ui/porteditorwidget.ui
@@ -74,12 +74,18 @@
     </widget>
    </item>
    <item>
-    <widget class="QLineEdit" name="typeEdit">
-     <property name="text">
-      <string/>
+    <widget class="QComboBox" name="typeEdit">
+     <property name="editable">
+      <bool>true</bool>
      </property>
-     <property name="placeholderText">
-      <string>Data Type</string>
+     <property name="currentText">
+      <string extracomment="port type"/>
+     </property>
+     <property name="frame">
+      <bool>true</bool>
+     </property>
+     <property name="modelColumn">
+      <number>0</number>
      </property>
     </widget>
    </item>
@@ -109,13 +115,6 @@
     <widget class="QPushButton" name="optionalButton">
      <property name="text">
       <string>Required</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>     </string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
The user can now use a dropdown menu to choose between the following python types:
- str
- int
- float
- bool
- list
- set
- tuple
- dict

The user actually sees a list of "pretty" types such as "String", "Integer", "Floating Point", etc.

If the user wants to use a custom type, they can by typing in the combo box. If the user does this, they will be presented with:
- a warning confirmation box if the type is a valid python identifier
- an error if the type is not a valid python identifier.

The warning message box looks like this:
![image](https://user-images.githubusercontent.com/19242154/80047011-2571f000-84c1-11ea-95a7-8e3d356c7a23.png)

The user can see the details by clicking "Show Details...", which will look like this:
![image](https://user-images.githubusercontent.com/19242154/80047070-489c9f80-84c1-11ea-8e58-23f3a0c5aec6.png)

The configuration that makes this warning happen is:
![image](https://user-images.githubusercontent.com/19242154/80047192-9e714780-84c1-11ea-8749-b49c25ef9060.png)

resolves #202