### PR TITLE
no parent/width bugfixes

### DIFF
--- a/src/data/statemachine.py
+++ b/src/data/statemachine.py
@@ -576,10 +576,10 @@ class StateMachine:
 		observer = self._project.getObserver()
 		
 		if mode == StateMachine.ExplorationMode.AUTO:
-			explorer.play()
+			# explorer.play()  # TODO: Uncomment when explorer is fixed
 			observer.play()
 		elif mode == StateMachine.ExplorationMode.MANUAL:
-			explorer.pause()
+			# explorer.pause()
 			observer.play()
 		
 		self.view.ui.actionAutoExplore.setEnabled(True)

--- a/src/graphics/tguim/componentgraphics.py
+++ b/src/graphics/tguim/componentgraphics.py
@@ -97,16 +97,18 @@ class ComponentGraphics(QGraphicsItem):
         
         # --- MENUS --- #
         # Menus like to be special so this section puts them back in their place (both literally and figuratively)
-        if self._depth >= 0:
+        if self._depth == 0:
             type = self._dataComponent.getSuperToken().getTokens()[0].type
             
             if type is 'Menu' and parent:
                 self.isMenu = True
                 self._depth = 0
                 nxtParent = parent
-                while not isinstance(nxtParent, TopLevelWrapperGraphics):
+                while not isinstance(nxtParent, TopLevelWrapperGraphics) and nxtParent:
                     self._depth += 1
                     nxtParent = nxtParent.parentItem()
+                if not nxtParent:
+                    self._depth = 1
 
             # Some menus are actually menuItems (who would've thought they would be even more annoying than
             # they already are?), so this resets those menuitems' depths back to normal, and adds them to the


### PR DESCRIPTION
Fixed bugs with no component width or parents. Also fixed bug with explorer being used when it isn't fully implemented yet. Tested with Notepad++ v7.8.6

Closes #254 