### PR TITLE
use half-transparent gray color for VBs that are connected to a hidde…

### DIFF
--- a/src/graphics/tguim/visibilitybehaviorgraphics.py
+++ b/src/graphics/tguim/visibilitybehaviorgraphics.py
@@ -21,6 +21,8 @@
 This module contains the VBGraphics class.
 """
 
+from copy import copy
+
 from PySide2.QtCore import QRectF
 from PySide2.QtGui import QPainterPath, QPainter, QPen, Qt, QColor, QBrush, QPainterPathStroker, QContextMenuEvent, \
     QMouseEvent
@@ -36,7 +38,8 @@ class VBGraphics(QAbstractGraphicsShapeItem):
     MIN_LEFT_DIST = 20
     ARROW_COL = QColor(230, 230, 230)
     SEL_ARROW_COL = QColor(255, 200, 50)
-    HIDDEN_ARROW_COL = QColor(230, 230, 230, 50)
+    HIDDEN_ARROW_COL = copy(ARROW_COL)
+    HIDDEN_ARROW_COL.setAlpha(round(ARROW_COL.alpha()/2))
 
     def __init__(self, dataVisibilityBehavior: 'VisibilityBehavior', parent: 'TGUIMScene'):
         """


### PR DESCRIPTION
When a VB is connected to a component that's hidden, the color of the VB is half-transparent (only when not selected)

![image](https://user-images.githubusercontent.com/19242154/83952988-b0991200-a7f1-11ea-9ebf-fcfc597353be.png)

![image](https://user-images.githubusercontent.com/19242154/83953033-feae1580-a7f1-11ea-8750-acdaf31513bb.png)

@Frenchman98 This PR will merge into the VB-Routing branch if you want this enhancement. If you don't want it, you can just close the PR.

---

BTW, I recently started having an issue where the first menu I select in notepad isn't detected as an EC, but it shown outside of the main window. I don't think that this is what's causing the issue, but it would be best if you make sure before merging this.