### PR TITLE
Created environment report generator script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ future==0.18.2
 idna==2.9
 imageio==2.8.0
 imagesize==1.2.0
-IntelliWave-API==0.1.0
 jdcal==1.4.1
 Jinja2==2.11.2
 joblib==0.14.1
@@ -31,9 +30,6 @@ matplotlib==3.2.1
 MouseInfo==0.1.3
 networkx==2.4
 nltk==3.5
-Notepad==0.1.0
-Notepad-API==0.1.0
-NotepadAPI==0.1.0
 numpy==1.17.2
 openpyxl==3.0.2
 packaging==20.3

--- a/scripts/environment_report.py
+++ b/scripts/environment_report.py
@@ -1,0 +1,86 @@
+import sys
+import pygit2
+import platform
+import subprocess
+
+
+env_stub_template = """
+<details>
+
+### Machine
+- **OS**: {os}
+
+---
+
+### Python
+{python_version}
+<details>
+<summary>Packages</summary>
+Package Name | Version
+------------ | -------   
+{python_packages}
+
+</details>
+
+---
+
+### Facile
+- **Branch Name**: {git_branch}
+- **Commit Hash**: {git_commit}
+
+---
+
+{target_app_info}
+
+{additional_info}
+
+</details>
+"""
+
+def getEnvironmentStub():
+    # OS info
+    os = platform.platform()
+
+    # Python info
+    python_version = sys.version
+    packages = subprocess.run(['pip', 'freeze'], stdout=subprocess.PIPE).stdout.decode('utf-8').split()
+    python_packages = "\n".join([f'{p.split("==")[0]} | {p.split("==")[1]}' for p in packages])
+
+    # Repo information
+    repo = pygit2.Repository("../")
+    git_branch = repo.head.shorthand
+    git_commit = repo.revparse_single('HEAD^').hex
+
+    # Target App info
+    target_app_name = input("What's the name of your target application [N/A]? ")
+    target_app_name = target_app_name if target_app_name.strip() else "N/A"
+    if target_app_name != "N/A":
+        target_app_version = input("What's the version of your target application [N/A]? ")
+        target_app_version = target_app_version if target_app_version.strip() else "N/A"
+        target_app_info = f"### Target Application\n" \
+                          f"- **Name**: {target_app_name}\n" \
+                          f"- **Version**: {target_app_version}\n"
+    else:
+        target_app_info = ""
+
+    # Additional environment information
+    additional_info = input("Is there any additional information you'd like to share about your setup [N/A]? ")
+    additional_info = additional_info if additional_info.strip() else "N/A"
+    if additional_info != "N/A":
+        additional_info = "---\n\n### Additional context\n" \
+                          f"{additional_info}"
+    else:
+        additional_info = ""
+
+    report_md = env_stub_template.format(os=os,
+                                         python_version=python_version,
+                                         python_packages=python_packages,
+                                         git_branch=git_branch,
+                                         git_commit=git_commit,
+                                         target_app_info=target_app_info,
+                                         additional_info=additional_info)
+
+    return report_md
+
+if __name__ == "__main__":
+    print(getEnvironmentStub())


### PR DESCRIPTION
A recently-added feature to our repository is [issue templates](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository). They should help us create issues that give more detailed information. The bug report template asks for environment information, but that can be tedious to gather, so I wrote a script that generates it automatically.

The script should be run in pycharm to ensure the appropriate interpreter is being used (venv if it exists). The output of the script (including the <detail> and </detail> tags) should be copied directly into the issue.