### PR TITLE
Revert "pip prod(deps): bump cx-freeze from 6.1 to 6.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ chardet==3.0.4
 click==7.1.2
 colorama==0.4.3
 comtypes==1.1.7
-cx-Freeze==6.2
+cx-Freeze==6.1
 cycler==0.10.0
 decorator==4.4.2
 docutils==0.16


### PR DESCRIPTION
The bump created the issue [here](https://github.com/facade-technologies-inc/facile/pull/364#issuecomment-656412072)

Reverts facade-technologies-inc/facile#363